### PR TITLE
SECURESIGN-115 | Add new label to dockerfiles for Comet

### DIFF
--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -43,6 +43,7 @@ LABEL io.k8s.description="The timestamp-authority is a process that provides a t
 LABEL io.k8s.display-name="Timestamp-authority container image for Red Hat Trusted Signer."
 LABEL io.openshift.tags="TSA trusted-signer."
 LABEL summary="Provides a timestamp-authority image."
+LABEL com.redhat.component="timestamp-authority"
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/timestamp-server /usr/local/bin/timestamp-server


### PR DESCRIPTION
This pr is related to this issue https://issues.redhat.com/browse/SECURESIGN-115, and involves adding an extra label to the Dockerfile for Comet.