### PR TITLE
chore: modify update script to avoid merge conflicts

### DIFF
--- a/redhat/release/update-to-head.sh
+++ b/redhat/release/update-to-head.sh
@@ -53,10 +53,15 @@ robot_trigger_msg=":robot: triggering CI on branch '${redhat_ref}' after synchin
 # Reset release-next to upstream main or <git-ref>.
 git fetch upstream $upstream_ref
 if [[ "$upstream_ref" == "main" ]]; then
-  git checkout upstream/main -B ${redhat_ref}
+  git checkout upstream/main -B ${redhat_ref}-ci
 else
-  git checkout $upstream_ref -B ${redhat_ref}
+  git checkout $upstream_ref -B ${redhat_ref}-ci
 fi
+
+# RHTAP writes its pipeline files to the root of ${redhat_ref}
+# Fetch those from origin and merge them into the ci branch
+git fetch origin $redhat_ref
+git merge origin/$redhat_ref --no-edit
 
 # Update redhat's main and take all needed files from there.
 git fetch origin $midstream_ref
@@ -67,18 +72,9 @@ if [[ -d redhat/patches ]]; then
   git apply redhat/patches/*
 fi
 
-# RHTAP writes its pipeline files to the root of ${redhat_ref}
-# Fetch those from origin and apply them to the the release branch
-# since we just wiped out our local copy with the upstream ref.
-git fetch origin $redhat_ref
-git checkout origin/$redhat_ref .tekton
-
 # Move overlays to root
 if [[ -d redhat/overlays ]]; then
-  if [[ -f redhat/overlays/Dockerfile ]]; then
-      git rm Dockerfile
-  fi
-  git mv redhat/overlays/* .
+  mv redhat/overlays/* .
 fi
 
 git add . # Adds applied patches
@@ -86,8 +82,6 @@ git add $custom_files # Adds custom files
 git commit -m "${redhat_files_msg}"
 
 # Trigger CI
-# TODO: Set up openshift or github CI to run on release-next-ci
-git checkout "${redhat_ref}" -B "${redhat_ref}"-ci
 date > ci
 git add ci
 git commit -m "${robot_trigger_msg}"


### PR DESCRIPTION
By simply overwriting the history for the release branch, the update script is prone to merge conflicts when updating the release branch. This change modifies the update script to consider the release branch as the canonical branch, merging it into the release-ci branch with each sync update.