### PR TITLE
fix: remove the cel expressions in the push pipelines

### DIFF
--- a/.tekton/timestamp-authority-1-0-gamma-push.yaml
+++ b/.tekton/timestamp-authority-1-0-gamma-push.yaml
@@ -6,8 +6,6 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "redhat-v1.2"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: tsa-1-0-gamma


### PR DESCRIPTION
remove the cel expressions in the push pipelines so that they always run on any push to the release branch.