### PR TITLE
SECURESIGN-1272 | Add multi arch build file, and Dockerfile for fetch_tsa_certs

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,0 +1,30 @@
+.PHONY: 
+cross-platform: fetch-tsa-certs-darwin-arm64 fetch-tsa-certs-darwin-amd64 fetch-tsa-certs-linux-amd64 fetch-tsa-certs-linux-arm64 fetch-tsa-certs-linux-ppc64le fetch-tsa-certs-linux-s390x fetch-tsa-certs-windows ## Build all distributable (cross-platform) binaries
+
+.PHONY:	fetch-tsa-certs-darwin-arm64
+fetch-tsa-certs-darwin-arm64: ## Build for mac M1
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=readonly -o fetch_tsa_certs_darwin_arm64 -trimpath ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-darwin-amd64
+fetch-tsa-certs-darwin-amd64:  ## Build for Darwin (macOS)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=readonly -o fetch_tsa_certs_darwin_amd64 -trimpath ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-linux-amd64 
+fetch-tsa-certs-linux-amd64: ## Build for Linux amd64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=readonly -o fetch_tsa_certs_linux_amd64 -trimpath ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-linux-arm64
+fetch-tsa-certs-linux-arm64: ## Build for Linux arm64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod=readonly -o fetch_tsa_certs_linux_arm64 -trimpath ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-linux-ppc64le
+fetch-tsa-certs-linux-ppc64le: ## Build for Linux ppc64le
+	env CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -mod=readonly -o fetch_tsa_certs_linux_ppc64le -trimpath ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-linux-s390x
+fetch-tsa-certs-linux-s390x:  ## Build for Linux s390x
+	env CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -mod=readonly -o fetch_tsa_certs_linux_s390x -trimpath ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-windows
+fetch-tsa-certs-windows: ## Build for Windows
+	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=readonly -o fetch_tsa_certs_windows_amd64.exe -trimpath ./cmd/fetch-tsa-certs

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -1,0 +1,49 @@
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:5049a9d9be3914049aa983b66c695047d87c248f5fc95a222a63a15578a376bc as build-env
+ENV APP_ROOT=/opt/app-root
+ENV GOPATH=$APP_ROOT
+WORKDIR $APP_ROOT/src/
+
+ADD go.mod go.sum $APP_ROOT/src/
+RUN go mod download
+
+ADD ./cmd/ $APP_ROOT/src/cmd/
+ADD ./pkg/ $APP_ROOT/src/pkg/
+ADD ./Build.mak $APP_ROOT/src/Build.mak
+
+RUN make -f Build.mak cross-platform && \
+    gzip fetch_tsa_certs_darwin_arm64 && \
+    gzip fetch_tsa_certs_darwin_amd64 && \
+    gzip fetch_tsa_certs_linux_amd64 && \
+    gzip fetch_tsa_certs_linux_arm64 && \
+    gzip fetch_tsa_certs_linux_ppc64le && \
+    gzip fetch_tsa_certs_linux_s390x && \
+    gzip fetch_tsa_certs_windows_amd64.exe
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:73f7dcacb460dad137a58f24668470a5a2e47378838a0190eef0ab532c6e8998
+ENV APP_ROOT=/opt/app-root
+WORKDIR $APP_ROOT/src/
+
+LABEL description="The fetch_tsa_certs binary is a cli used to configure the kms and tink signer types for Timestamp Authority."
+LABEL io.k8s.description="The fetch_tsa_certs binary is a cli used to configure the kms and tink signer types for Timestamp Authority."
+LABEL io.k8s.display-name="Fetch TSA certs container image for Red Hat Trusted Signer."
+LABEL io.openshift.tags="fetch_tsa_certs"
+LABEL summary="Provides fetch_tsa_certs images."
+LABEL com.redhat.component="fetch_tsa_certs"
+LABEL name="fetch_tsa_certs"
+
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_darwin_arm64.gz /usr/local/bin/fetch_tsa_certs_darwin_arm64.gz
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_darwin_amd64.gz /usr/local/bin/fetch_tsa_certs_darwin_amd64.gz
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_linux_amd64.gz /usr/local/bin/fetch_tsa_certs_linux_amd64.gz
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_linux_arm64.gz /usr/local/bin/fetch_tsa_certs_linux_arm64.gz
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_linux_ppc64le.gz /usr/local/bin/fetch_tsa_certs_linux_ppc64le.gz
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_linux_s390x.gz /usr/local/bin/fetch_tsa_certs_linux_s390x.gz
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_windows_amd64.exe.gz /usr/local/bin/fetch_tsa_certs_windows_amd64.exe.gz
+
+RUN chown root:0 /usr/local/bin/fetch_tsa_certs_darwin_arm64.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_darwin_arm64.gz && \
+    chown root:0 /usr/local/bin/fetch_tsa_certs_darwin_amd64.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_darwin_amd64.gz && \
+    chown root:0 /usr/local/bin/fetch_tsa_certs_linux_arm64.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_linux_arm64.gz && \
+    chown root:0 /usr/local/bin/fetch_tsa_certs_linux_amd64.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_linux_amd64.gz && \
+    chown root:0 /usr/local/bin/fetch_tsa_certs_linux_ppc64le.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_linux_ppc64le.gz && \
+    chown root:0 /usr/local/bin/fetch_tsa_certs_linux_s390x.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_linux_s390x.gz && \
+    chown root:0 /usr/local/bin/fetch_tsa_certs_windows_amd64.exe.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_windows_amd64.exe.gz && \
+    chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}


### PR DESCRIPTION
Adds a multi arch build file for fetch_tsa_certs, and adds a Dockerfile to build 