### PR TITLE
feat(fips): bumping Go to 1.24

### DIFF
--- a/.tekton/fetch-tsa-certs-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-pull-request.yaml
@@ -44,8 +44,6 @@ spec:
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-cli ./cmd/timestamp-cli
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-server ./cmd/timestamp-server
       go test ./...
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/fetch-tsa-certs-push.yaml
+++ b/.tekton/fetch-tsa-certs-push.yaml
@@ -41,8 +41,6 @@ spec:
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-cli ./cmd/timestamp-cli
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-server ./cmd/timestamp-server
       go test ./...
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/timestamp-authority-pull-request.yaml
+++ b/.tekton/timestamp-authority-pull-request.yaml
@@ -44,8 +44,6 @@ spec:
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-cli ./cmd/timestamp-cli
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-server ./cmd/timestamp-server
       go test ./...
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/timestamp-authority-push.yaml
+++ b/.tekton/timestamp-authority-push.yaml
@@ -41,8 +41,6 @@ spec:
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-cli ./cmd/timestamp-cli
       CGO_ENABLED=0 go build -trimpath -o bin/timestamp-server ./cmd/timestamp-server
       go test ./...
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -1,4 +1,6 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 as build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 as build-env
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 WORKDIR $APP_ROOT/src/

--- a/Dockerfile.tsa.rh
+++ b/Dockerfile.tsa.rh
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 as builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 
@@ -24,17 +26,17 @@ ADD ./pkg/ $APP_ROOT/src/pkg/
 
 RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod download && \
-    CGO_ENABLED=0 go build -mod=readonly -ldflags "${SERVER_LDFLAGS}" ./cmd/timestamp-server
+    go build -mod=readonly -ldflags "${SERVER_LDFLAGS}" ./cmd/timestamp-server
 
 # debug compile options & debugger
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 as debug
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0
 
 # overwrite server and include debugger
 COPY --from=builder /opt/app-root/src/timestamp-server_debug /usr/local/bin/timestamp-server
 
 # Multi-Stage production build
-FROM registry.access.redhat.com/ubi9-minimal@sha256:6d5a6576c83816edcc0da7ed62ba69df8f6ad3cbe659adde2891bfbec4dbf187 as deploy
+FROM registry.access.redhat.com/ubi9-minimal@sha256:6d5a6576c83816edcc0da7ed62ba69df8f6ad3cbe659adde2891bfbec4dbf187 AS deploy
 
 LABEL description="The timestamp-authority is a process that provides a timestamp record of when a document was created or modified."
 LABEL io.k8s.description="The timestamp-authority is a process that provides a timestamp record of when a document was created or modified."


### PR DESCRIPTION
## Summary by Sourcery

Bump Go toolchain to version 1.24 for FIPS compliance and update related build and CI configurations

Enhancements:
- Upgrade Go toolchain to version 1.24

Build:
- Update fetch_tsa_certs and tsa Dockerfiles to use Go 1.24 base images

CI:
- Remove hardcoded go_base_image references from Tekton pipeline definitions