### PR TITLE
cherry-pick - feat: add configurable max request body size for TSA server

### DIFF
--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -78,6 +78,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("disable-ntp-monitoring", false, "Disables NTP monitoring. Defaults to false")
 
 	rootCmd.PersistentFlags().String("http-request-id-header-name", middleware.RequestIDHeader, "name of HTTP Request Header to use as request correlation ID")
+	rootCmd.PersistentFlags().Uint64("max-request-body-size", 1048576, "Maximum allowed size for request bodies in bytes (1MB by default)")
 
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Logger.Fatal(err)

--- a/pkg/generated/restapi/configure_timestamp_server.go
+++ b/pkg/generated/restapi/configure_timestamp_server.go
@@ -19,6 +19,7 @@ package restapi
 
 import (
 	"crypto/tls"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/cors"
+	"github.com/spf13/viper"
 	"github.com/urfave/negroni"
 
 	pkgapi "github.com/sigstore/timestamp-authority/pkg/api"
@@ -123,6 +125,24 @@ func httpPingOnly() func(http.Handler) http.Handler {
 	return f
 }
 
+// limitRequestBody restricts the maximum size of incoming request bodies based on the configured "max-request-body-size" value.
+// Requests exceeding the limit are terminated with an HTTP 413 error.
+func limitRequestBody(next http.Handler) http.Handler {
+	const maxInt64Limit int64 = math.MaxInt64
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		maxRequestBodySize := viper.GetUint64("max-request-body-size")
+		if maxRequestBodySize > 0 {
+			if maxRequestBodySize > uint64(math.MaxInt64) {
+				log.Logger.Fatalf("max-request-body-size (%v) exceeds supported maximum (%v)", maxRequestBodySize, maxInt64Limit)
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, int64(maxRequestBodySize))
+		} else {
+			log.Logger.Debug("max-request-body-size is set to 0; no limit will be enforced on request body sizes")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics.
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
@@ -139,6 +159,8 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	returnHandler = handleCORS(returnHandler)
 
 	returnHandler = wrapMetrics(returnHandler)
+
+	returnHandler = limitRequestBody(returnHandler)
 
 	return middleware.RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()


### PR DESCRIPTION
* feat: add configurable max request body size for TSA server

## Summary by Sourcery

Introduce a configurable maximum request body size for the TSA server, defaulting to 1MB, to prevent excessively large payloads.

New Features:
- Add a max-request-body-size CLI flag on the TSA server with a 1MB default
- Enforce the configured max request body size in the server's request handling