### PR TITLE
Update release-version to 1.3.5

### DIFF
--- a/.tekton/fetch-tsa-certs-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.4"
+    value: "1.3.5"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/fetch-tsa-certs-push.yaml
+++ b/.tekton/fetch-tsa-certs-push.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.4"
+    value: "1.3.5"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/timestamp-authority-pull-request.yaml
+++ b/.tekton/timestamp-authority-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.4"
+    value: "1.3.5"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/timestamp-authority-push.yaml
+++ b/.tekton/timestamp-authority-push.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.4"
+    value: "1.3.5"
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
## Summary
- Update release-version parameter to 1.3.5 in Tekton pipeline files

## Test plan
- Verify Tekton pipelines run with version 1.3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)