### PR TITLE
Update release-version to 1.4.1

### DIFF
--- a/.tekton/fetch-tsa-certs-cli-stack-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-cli-stack-pull-request.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.4.1
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: git-url

--- a/.tekton/fetch-tsa-certs-cli-stack-push.yaml
+++ b/.tekton/fetch-tsa-certs-cli-stack-push.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.4.1
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: git-url


### PR DESCRIPTION
## Summary
- Update release-version parameter from 1.4.0 to 1.4.1 in Tekton pipeline files

## Test plan
- Verify Tekton pipelines run with version 1.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)