### PR TITLE
build: rework cli-stack and fix multi-arch digests for release-1.4

### DIFF
--- a/.tekton/fetch-tsa-certs-cli-stack-push.yaml
+++ b/.tekton/fetch-tsa-certs-cli-stack-push.yaml
@@ -28,6 +28,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
     value: "false"
   - name: build-source-image

--- a/Build.mak
+++ b/Build.mak
@@ -1,16 +1,20 @@
 FIPS_MODULE ?= latest
 
-.PHONY: 
+.PHONY: fetch-tsa-certs-linux
+fetch-tsa-certs-linux: ## Build native Linux binary (FIPS, CGO)
+	env CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod=readonly -buildvcs=false -o fetch_tsa_certs -trimpath ./cmd/fetch-tsa-certs
+
+.PHONY:
 cross-platform: fetch-tsa-certs-darwin-arm64 fetch-tsa-certs-darwin-amd64 fetch-tsa-certs-windows ## Build all distributable (cross-platform) binaries
 
 .PHONY:	fetch-tsa-certs-darwin-arm64
 fetch-tsa-certs-darwin-arm64: ## Build for mac M1
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build -mod=readonly -o fetch_tsa_certs_darwin_arm64 -trimpath ./cmd/fetch-tsa-certs
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build -mod=readonly -buildvcs=false -o fetch_tsa_certs_darwin_arm64 -trimpath ./cmd/fetch-tsa-certs
 
 .PHONY: fetch-tsa-certs-darwin-amd64
 fetch-tsa-certs-darwin-amd64:  ## Build for Darwin (macOS)
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build -mod=readonly -o fetch_tsa_certs_darwin_amd64 -trimpath ./cmd/fetch-tsa-certs
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build -mod=readonly -buildvcs=false -o fetch_tsa_certs_darwin_amd64 -trimpath ./cmd/fetch-tsa-certs
 
 .PHONY: fetch-tsa-certs-windows
 fetch-tsa-certs-windows: ## Build for Windows
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build -mod=readonly -o fetch_tsa_certs_windows_amd64.exe -trimpath ./cmd/fetch-tsa-certs
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build -mod=readonly -buildvcs=false -o fetch_tsa_certs_windows_amd64.exe -trimpath ./cmd/fetch-tsa-certs

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -1,53 +1,59 @@
-FROM --platform=linux/amd64   quay.io/securesign/fetch-tsa-certs@sha256:c989c06cadc67072738855831435edc284afb901f96bfe6c27eb9f84ce2b4529 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/fetch-tsa-certs@sha256:c1df2a7c019937c3848479483df0b595e6f550c402544e077bca1776a2932beb AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/fetch-tsa-certs@sha256:5bbd34a8976d50c3db383a2156cfb8d61d3af385fae7764c33e9ad52673bb679 AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/fetch-tsa-certs@sha256:2b579cc28c4c6555a0637e518bbd3af3c561d49988edf69b2115c8aa2e909fa0 AS build-s390x
+FROM registry.redhat.io/ubi9/go-toolset:9.8-1779959429@sha256:a2ba4645e7c424b08aa83ed7792e279683b0d33acbc5131b18183fd21e336c55 AS build-cross-platform
+ENV APP_ROOT=/opt/app-root \
+    GOPATH=/opt/app-root
+
+USER root
+WORKDIR $APP_ROOT/src
+ADD go.mod go.sum ./
+ADD ./ ./
+
+RUN git config --global --add safe.directory /opt/app-root/src && \
+    go mod download && \
+    make -f Build.mak cross-platform
+
+FROM --platform=linux/amd64   quay.io/securesign/fetch-tsa-certs@sha256:4f7bdb98e0f912cdee7d8b6293b832de5dfd826ae80b02103652c90637fb1fd5 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/fetch-tsa-certs@sha256:4f7bdb98e0f912cdee7d8b6293b832de5dfd826ae80b02103652c90637fb1fd5 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/fetch-tsa-certs@sha256:4f7bdb98e0f912cdee7d8b6293b832de5dfd826ae80b02103652c90637fb1fd5 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/fetch-tsa-certs@sha256:4f7bdb98e0f912cdee7d8b6293b832de5dfd826ae80b02103652c90637fb1fd5 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1779959429@sha256:a2ba4645e7c424b08aa83ed7792e279683b0d33acbc5131b18183fd21e336c55 AS packager
 USER root
 RUN mkdir -p /binaries
 
-# Native Linux binaries from each arch variant
-COPY --from=build-amd64 /usr/local/bin/fetch_tsa_certs_linux.gz /tmp/fetch_tsa_certs_linux.gz
-RUN gzip -d /tmp/fetch_tsa_certs_linux.gz && \
-    tar -czf /binaries/fetch_tsa_certs_linux_amd64.tar.gz -C /tmp fetch_tsa_certs_linux && \
-    rm /tmp/fetch_tsa_certs_linux
+# fetch_tsa_certs: Native Linux binaries from each arch variant
+COPY --from=build-amd64 /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+RUN tar -czf /binaries/fetch_tsa_certs_linux_amd64.tar.gz -C /tmp fetch_tsa_certs && \
+    rm /tmp/fetch_tsa_certs
 
-COPY --from=build-arm64 /usr/local/bin/fetch_tsa_certs_linux.gz /tmp/fetch_tsa_certs_linux.gz
-RUN gzip -d /tmp/fetch_tsa_certs_linux.gz && \
-    tar -czf /binaries/fetch_tsa_certs_linux_arm64.tar.gz -C /tmp fetch_tsa_certs_linux && \
-    rm /tmp/fetch_tsa_certs_linux
+COPY --from=build-arm64 /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+RUN tar -czf /binaries/fetch_tsa_certs_linux_arm64.tar.gz -C /tmp fetch_tsa_certs && \
+    rm /tmp/fetch_tsa_certs
 
-COPY --from=build-ppc64le /usr/local/bin/fetch_tsa_certs_linux.gz /tmp/fetch_tsa_certs_linux.gz
-RUN gzip -d /tmp/fetch_tsa_certs_linux.gz && \
-    tar -czf /binaries/fetch_tsa_certs_linux_ppc64le.tar.gz -C /tmp fetch_tsa_certs_linux && \
-    rm /tmp/fetch_tsa_certs_linux
+COPY --from=build-ppc64le /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+RUN tar -czf /binaries/fetch_tsa_certs_linux_ppc64le.tar.gz -C /tmp fetch_tsa_certs && \
+    rm /tmp/fetch_tsa_certs
 
-COPY --from=build-s390x /usr/local/bin/fetch_tsa_certs_linux.gz /tmp/fetch_tsa_certs_linux.gz
-RUN gzip -d /tmp/fetch_tsa_certs_linux.gz && \
-    tar -czf /binaries/fetch_tsa_certs_linux_s390x.tar.gz -C /tmp fetch_tsa_certs_linux && \
-    rm /tmp/fetch_tsa_certs_linux
+COPY --from=build-s390x /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+RUN tar -czf /binaries/fetch_tsa_certs_linux_s390x.tar.gz -C /tmp fetch_tsa_certs && \
+    rm /tmp/fetch_tsa_certs
 
-# Darwin amd64
-COPY --from=build-amd64 /usr/local/bin/fetch_tsa_certs_darwin_amd64.gz /tmp/fetch_tsa_certs_darwin_amd64.gz
-RUN gzip -d /tmp/fetch_tsa_certs_darwin_amd64.gz && \
-    tar -czf /binaries/fetch_tsa_certs_darwin_amd64.tar.gz -C /tmp fetch_tsa_certs_darwin_amd64 && \
+# fetch_tsa_certs: Cross-compiled binaries
+COPY --from=build-cross-platform /opt/app-root/src/fetch_tsa_certs_darwin_amd64 /tmp/fetch_tsa_certs_darwin_amd64
+RUN tar -czf /binaries/fetch_tsa_certs_darwin_amd64.tar.gz -C /tmp fetch_tsa_certs_darwin_amd64 && \
     rm /tmp/fetch_tsa_certs_darwin_amd64
 
-# Darwin arm64
-COPY --from=build-amd64 /usr/local/bin/fetch_tsa_certs_darwin_arm64.gz /tmp/fetch_tsa_certs_darwin_arm64.gz
-RUN gzip -d /tmp/fetch_tsa_certs_darwin_arm64.gz && \
-    tar -czf /binaries/fetch_tsa_certs_darwin_arm64.tar.gz -C /tmp fetch_tsa_certs_darwin_arm64 && \
+COPY --from=build-cross-platform /opt/app-root/src/fetch_tsa_certs_darwin_arm64 /tmp/fetch_tsa_certs_darwin_arm64
+RUN tar -czf /binaries/fetch_tsa_certs_darwin_arm64.tar.gz -C /tmp fetch_tsa_certs_darwin_arm64 && \
     rm /tmp/fetch_tsa_certs_darwin_arm64
 
-# Windows amd64
-COPY --from=build-amd64 /usr/local/bin/fetch_tsa_certs_windows_amd64.exe.gz /tmp/fetch_tsa_certs_windows_amd64.exe.gz
-RUN gzip -d /tmp/fetch_tsa_certs_windows_amd64.exe.gz && \
-    tar -czf /binaries/fetch_tsa_certs_windows_amd64.tar.gz -C /tmp fetch_tsa_certs_windows_amd64.exe && \
+COPY --from=build-cross-platform /opt/app-root/src/fetch_tsa_certs_windows_amd64.exe /tmp/fetch_tsa_certs_windows_amd64.exe
+RUN tar -czf /binaries/fetch_tsa_certs_windows_amd64.tar.gz -C /tmp fetch_tsa_certs_windows_amd64.exe && \
     rm /tmp/fetch_tsa_certs_windows_amd64.exe
 
+RUN chmod -R a+rX /binaries
+
 # Final minimal image with all binaries
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
 LABEL description="Flat image containing fetch-tsa-certs CLI binaries for all platforms and architectures"
 LABEL io.k8s.description="Flat image containing fetch-tsa-certs CLI binaries for all platforms and architectures"
@@ -56,10 +62,9 @@ LABEL io.k8s.display-name="Fetch TSA certs CLI stack image for Red Hat Trusted A
 LABEL io.openshift.tags="fetch-tsa-certs trusted-artifact-signer cli-stack"
 LABEL summary="Provides all fetch-tsa-certs CLI binaries as tar.gz archives for CDN distribution."
 LABEL com.redhat.component="fetch-tsa-certs-cli-stack"
+LABEL name="rhtas/fetch-tsa-certs-cli-stack"
 
 COPY --from=packager /binaries/ /binaries/
 COPY --from=build-amd64 /licenses/ /licenses/
-
-RUN chown -R root:0 /binaries && chmod -R g+r /binaries
 
 USER 65532:65532

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -12,12 +12,7 @@ ADD ./cmd/ $APP_ROOT/src/cmd/
 ADD ./pkg/ $APP_ROOT/src/pkg/
 ADD ./Build.mak $APP_ROOT/src/Build.mak
 
-RUN go build -mod=readonly -o fetch_tsa_certs_linux -trimpath ./cmd/fetch-tsa-certs && \
-    gzip -k fetch_tsa_certs_linux && \
-    make -f Build.mak cross-platform && \
-    gzip fetch_tsa_certs_darwin_arm64 && \
-    gzip fetch_tsa_certs_darwin_amd64 && \
-    gzip fetch_tsa_certs_windows_amd64.exe
+RUN make -f Build.mak fetch-tsa-certs-linux
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362
 ENV APP_ROOT=/opt/app-root
@@ -33,14 +28,8 @@ LABEL name="rhtas/fetch-tsa-certs-rhel9"
 
 COPY LICENSE /licenses/license.txt
 
-COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_linux /usr/local/bin/fetch_tsa_certs_linux
-COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_linux.gz /usr/local/bin/fetch_tsa_certs_linux.gz
-COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_darwin_arm64.gz /usr/local/bin/fetch_tsa_certs_darwin_arm64.gz
-COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_darwin_amd64.gz /usr/local/bin/fetch_tsa_certs_darwin_amd64.gz
-COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs_windows_amd64.exe.gz /usr/local/bin/fetch_tsa_certs_windows_amd64.exe.gz
+COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs /usr/local/bin/fetch_tsa_certs
 
-RUN chown root:0 /usr/local/bin/fetch_tsa_certs_linux.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_linux.gz && \
-    chown root:0 /usr/local/bin/fetch_tsa_certs_darwin_arm64.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_darwin_arm64.gz && \
-    chown root:0 /usr/local/bin/fetch_tsa_certs_darwin_amd64.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_darwin_amd64.gz && \
-    chown root:0 /usr/local/bin/fetch_tsa_certs_windows_amd64.exe.gz && chmod g+wx /usr/local/bin/fetch_tsa_certs_windows_amd64.exe.gz && \
-    chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+USER 65532:65532
+
+ENTRYPOINT ["fetch_tsa_certs"]

--- a/Dockerfile.tsa.rh
+++ b/Dockerfile.tsa.rh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi9/go-toolset:9.8-1779959429@sha256:23c19e009965fac24c91d9df0135feb876051615918af74c9b1dc0f0c511b33b AS builder
+FROM registry.redhat.io/ubi9/go-toolset:9.8-1779959429@sha256:a2ba4645e7c424b08aa83ed7792e279683b0d33acbc5131b18183fd21e336c55 AS builder
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
 ENV APP_ROOT=/opt/app-root
@@ -29,7 +29,7 @@ RUN git config --global --add safe.directory /opt/app-root/src && \
     go build -mod=readonly -ldflags "${SERVER_LDFLAGS}" ./cmd/timestamp-server
 
 # debug compile options & debugger
-FROM registry.redhat.io/ubi9/go-toolset:9.8-1779959429@sha256:23c19e009965fac24c91d9df0135feb876051615918af74c9b1dc0f0c511b33b AS debug
+FROM registry.redhat.io/ubi9/go-toolset:9.8-1779959429@sha256:a2ba4645e7c424b08aa83ed7792e279683b0d33acbc5131b18183fd21e336c55 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0
 
 # overwrite server and include debugger


### PR DESCRIPTION
## Summary
Cherry-pick of the cli-stack rework from main, plus go-toolset multi-arch digest fix.

- **`Dockerfile.tsa.rh`**: Replace amd64-specific go-toolset digest with multi-arch manifest digest
- **`Dockerfile.fetch_tsa_certs.rh`**: Simplified to native-only build (no cross-compilation or gzip)
- **`Dockerfile.cli-stack.rh`**: Full rework — add `build-cross-platform` stage, use single multi-arch manifest digest (`sha256:4f7bdb98...`) for all 4 arch FROM lines, switch to `ubi-micro:9.8`, `chmod -R a+rX`
- **`Build.mak`**: Add `fetch-tsa-certs-linux` target for native-only build
- **Tekton push pipeline**: Add `prefetch-input` for gomod

Follows the pattern from main (commit `da11988`).

## Test plan
- [ ] TSA multi-platform build passes (amd64, arm64, ppc64le, s390x)
- [ ] Component image rebuilds with simplified Dockerfile
- [ ] CLI-stack build passes after component nudge
- [ ] Enterprise Contract passes