### PR TITLE
feat: FIPS 140-3 compliance fixes for SHA-1 SKID and EqualKeys

### DIFF
--- a/cmd/fetch-tsa-certs/fetch_tsa_certs.go
+++ b/cmd/fetch-tsa-certs/fetch_tsa_certs.go
@@ -142,10 +142,18 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 			return nil, fmt.Errorf("generating serial number: %w", err)
 		}
 
-		parentSkid, err := cryptoutils.SKID(parentPubKey)
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		var parentSkid []byte
+		if fips140.Enabled() {
+			parentSkid, err = tsx509.ComputeSKID(parentPubKey)
+		} else {
+			parentSkid, err = cryptoutils.SKID(parentPubKey)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("generating SKID hash: %w", err)
 		}
+		// ========================================
 		now := time.Now()
 		cert := &x509.Certificate{
 			SerialNumber: parentSn,
@@ -288,10 +296,18 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 		return nil, fmt.Errorf("generating serial number: %w", err)
 	}
 
-	skid, err := cryptoutils.SKID(leafPubKey)
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	var skid []byte
+	if fips140.Enabled() {
+		skid, err = tsx509.ComputeSKID(leafPubKey)
+	} else {
+		skid, err = cryptoutils.SKID(leafPubKey)
+	}
 	if err != nil {
 		return nil, err
 	}
+	// ========================================
 
 	cert := &x509.Certificate{
 		SerialNumber: sn,

--- a/pkg/signer/memory.go
+++ b/pkg/signer/memory.go
@@ -18,6 +18,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/fips140"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -105,10 +106,18 @@ func NewTimestampingCertWithChain(signer crypto.Signer) ([]*x509.Certificate, er
 		return nil, err
 	}
 
-	skid, err := cryptoutils.SKID(signer.Public())
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	var skid []byte
+	if fips140.Enabled() {
+		skid, err = tsx509.ComputeSKID(signer.Public())
+	} else {
+		skid, err = cryptoutils.SKID(signer.Public())
+	}
 	if err != nil {
 		return nil, err
 	}
+	// ========================================
 
 	cert := &x509.Certificate{
 		SerialNumber: sn,

--- a/pkg/x509/x509.go
+++ b/pkg/x509/x509.go
@@ -16,6 +16,8 @@ package x509
 
 import (
 	"crypto"
+	"crypto/fips140"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
@@ -113,11 +115,45 @@ func VerifyCertChain(certs []*x509.Certificate, signer crypto.Signer, enforceInt
 		}
 	}
 
-	// Verify the signer's public key matches the leaf certificate
-	if err := cryptoutils.EqualKeys(leaf.PublicKey, signer.Public()); err != nil {
-		return err
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// cryptoutils.EqualKeys calls SKID (SHA-1) in its error-message path,
+	// which panics under fips140=only. SHA-1 is used here only as a
+	// diagnostic key fingerprint, not for security.
+	var equalKeysErr error
+	fips140.WithoutEnforcement(func() {
+		equalKeysErr = cryptoutils.EqualKeys(leaf.PublicKey, signer.Public())
+	})
+	if equalKeysErr != nil {
+		return equalKeysErr
 	}
+	// ========================================
 
 	// Verify the key's strength
 	return goodkey.ValidatePubKey(signer.Public())
 }
+
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+type subjectPublicKeyInfo struct {
+	Algorithm        asn1.RawValue
+	SubjectPublicKey asn1.BitString
+}
+
+// ComputeSKID computes a Subject Key Identifier using SHA-256 (truncated to 20 bytes).
+// Use instead of cryptoutils.SKID when FIPS is enabled, since cryptoutils.SKID uses SHA-1
+// which panics under fips140=only.
+func ComputeSKID(pub crypto.PublicKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+	var spki subjectPublicKeyInfo
+	if _, err := asn1.Unmarshal(der, &spki); err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(spki.SubjectPublicKey.Bytes)
+	return hash[:20], nil
+}
+
+// ========================================


### PR DESCRIPTION
## Summary
- Add FIPS-safe `ComputeSKID()` using SHA-256 (truncated to 20 bytes, RFC 7093) in `pkg/x509`, used instead of `cryptoutils.SKID()` when `fips140.Enabled()` — avoids SHA-1 panic under `GODEBUG=fips140=only`
- Wrap `cryptoutils.EqualKeys()` with `fips140.WithoutEnforcement()` in `VerifyCertChain()` — SHA-1 is only used on the error path for diagnostic fingerprints, never in artifacts
- Follows the same patterns established in securesign/fulcio#401 and securesign/fulcio#405