### PR TITLE
feat: invert cli-stack build flow using pipeline wait mechanism

### DIFF
--- a/.tekton/fetch-tsa-certs-cli-stack-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-cli-stack-pull-request.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && ("cmd/fetch-tsa-certs/***".pathChanged() || "pkg/***".pathChanged()
+      || "Build.mak".pathChanged() || "Dockerfile.cli-stack.rh".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged()
+      || "trigger-konflux-builds.txt".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cli-stacks

--- a/.tekton/fetch-tsa-certs-cli-stack-push.yaml
+++ b/.tekton/fetch-tsa-certs-cli-stack-push.yaml
@@ -7,7 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && ("cmd/fetch-tsa-certs/***".pathChanged() || "pkg/***".pathChanged()
+      || "Build.mak".pathChanged() || "Dockerfile.cli-stack.rh".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged()
+      || "trigger-konflux-builds.txt".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cli-stacks

--- a/.tekton/fetch-tsa-certs-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-pull-request.yaml
@@ -8,9 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/fetch-tsa-certs-pull-request.yaml".pathChanged() || "cmd/fetch-tsa-certs/***".pathChanged()
-      || "pkg/***".pathChanged() || "Build.mak".pathChanged() || "Dockerfile.fetch_tsa_certs.rh".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "trigger-konflux-builds.txt".pathChanged()
+      == "main" && ("cmd/fetch-tsa-certs/***".pathChanged() || "pkg/***".pathChanged()
+      || "Build.mak".pathChanged() || "Dockerfile.fetch_tsa_certs.rh".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged()
+      || "trigger-konflux-builds.txt".pathChanged()
       )
   creationTimestamp: null
   labels:
@@ -37,23 +38,18 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
-  - name: go_unit_test
-    value: "true"
-  - name: go_test_command
-    value: |
-      CGO_ENABLED=0 go build -trimpath -o bin/timestamp-cli ./cmd/timestamp-cli
-      CGO_ENABLED=0 go build -trimpath -o bin/timestamp-server ./cmd/timestamp-server
-      go test ./...
   - name: build-platforms
     value:
       - linux/x86_64
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
-  - name: fips-check
-    value: "true"
+  - name: manager-pipelinerun-selector
+    value: "appstudio.openshift.io/application=cli-stacks,appstudio.openshift.io/component=fetch-tsa-certs-cli-stack,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (pull_request,incoming,retest-all-comment)"
+  - name: manager-registry-url
+    value: "quay.io/securesign/fetch-tsa-certs-cli-stack"
+  - name: manager-build-arg-name
+    value: "CLI_STACK_IMAGE"
   pipelineRef:
     params:
     - name: url
@@ -63,13 +59,6 @@ spec:
     - name: pathInRepo
       value: pipelines/docker-build-multi-platform-oci-ta.yaml
     resolver: git
-  taskRunSpecs:
-  - pipelineTaskName: run-unit-test
-    stepSpecs:
-    - computeResources:
-        limits:
-          memory: 5Gi
-      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-fetch-tsa-certs
   workspaces:

--- a/.tekton/fetch-tsa-certs-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-pull-request.yaml
@@ -50,8 +50,6 @@ spec:
     value: "appstudio.openshift.io/application=cli-stacks,appstudio.openshift.io/component=fetch-tsa-certs-cli-stack,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (pull_request,incoming,retest-all-comment)"
   - name: manager-registry-url
     value: "quay.io/securesign/fetch-tsa-certs-cli-stack"
-  - name: manager-build-arg-name
-    value: "CLI_STACK_REF"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/fetch-tsa-certs-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: build-platforms
     value:
       - linux/x86_64

--- a/.tekton/fetch-tsa-certs-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
   - name: manager-registry-url
     value: "quay.io/securesign/fetch-tsa-certs-cli-stack"
   - name: manager-build-arg-name
-    value: "CLI_STACK_IMAGE"
+    value: "CLI_STACK_REF"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/fetch-tsa-certs-push.yaml
+++ b/.tekton/fetch-tsa-certs-push.yaml
@@ -49,7 +49,7 @@ spec:
   - name: manager-registry-url
     value: "quay.io/securesign/fetch-tsa-certs-cli-stack"
   - name: manager-build-arg-name
-    value: "CLI_STACK_IMAGE"
+    value: "CLI_STACK_REF"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/fetch-tsa-certs-push.yaml
+++ b/.tekton/fetch-tsa-certs-push.yaml
@@ -48,8 +48,6 @@ spec:
     value: "appstudio.openshift.io/application=cli-stacks,appstudio.openshift.io/component=fetch-tsa-certs-cli-stack,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (push,incoming,retest-all-comment)"
   - name: manager-registry-url
     value: "quay.io/securesign/fetch-tsa-certs-cli-stack"
-  - name: manager-build-arg-name
-    value: "CLI_STACK_REF"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/fetch-tsa-certs-push.yaml
+++ b/.tekton/fetch-tsa-certs-push.yaml
@@ -2,15 +2,16 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: "Dockerfile.clients.rh,Dockerfile.cli-stack.rh"
+    build.appstudio.openshift.io/build-nudge-files: "Dockerfile.clients.rh"
     build.appstudio.openshift.io/repo: https://github.com/securesign/timestamp-authority?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/fetch-tsa-certs-push.yaml".pathChanged() || "cmd/fetch-tsa-certs/***".pathChanged()
-      || "pkg/***".pathChanged() || "Build.mak".pathChanged() || "Dockerfile.fetch_tsa_certs.rh".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "trigger-konflux-builds.txt".pathChanged()
+      == "main" && ("cmd/fetch-tsa-certs/***".pathChanged() || "pkg/***".pathChanged()
+      || "Build.mak".pathChanged() || "Dockerfile.fetch_tsa_certs.rh".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged()
+      || "trigger-konflux-builds.txt".pathChanged()
       )
   creationTimestamp: null
   labels:
@@ -35,23 +36,18 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
-  - name: go_unit_test
-    value: "true"
-  - name: go_test_command
-    value: |
-      CGO_ENABLED=0 go build -trimpath -o bin/timestamp-cli ./cmd/timestamp-cli
-      CGO_ENABLED=0 go build -trimpath -o bin/timestamp-server ./cmd/timestamp-server
-      go test ./...
   - name: build-platforms
     value:
       - linux/x86_64
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
-  - name: fips-check
-    value: "true"
+  - name: manager-pipelinerun-selector
+    value: "appstudio.openshift.io/application=cli-stacks,appstudio.openshift.io/component=fetch-tsa-certs-cli-stack,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (push,incoming,retest-all-comment)"
+  - name: manager-registry-url
+    value: "quay.io/securesign/fetch-tsa-certs-cli-stack"
+  - name: manager-build-arg-name
+    value: "CLI_STACK_IMAGE"
   pipelineRef:
     params:
     - name: url
@@ -61,13 +57,6 @@ spec:
     - name: pathInRepo
       value: pipelines/docker-build-multi-platform-oci-ta.yaml
     resolver: git
-  taskRunSpecs:
-  - pipelineTaskName: run-unit-test
-    stepSpecs:
-    - computeResources:
-        limits:
-          memory: 5Gi
-      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-fetch-tsa-certs
   workspaces:

--- a/.tekton/fetch-tsa-certs-push.yaml
+++ b/.tekton/fetch-tsa-certs-push.yaml
@@ -36,6 +36,8 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: build-platforms
     value:
       - linux/x86_64

--- a/Build.mak
+++ b/Build.mak
@@ -1,20 +1,40 @@
 FIPS_MODULE ?= latest
+BUILD_FLAGS = -mod=readonly -tags=no_openssl -buildvcs=false -trimpath
 
 .PHONY: fetch-tsa-certs-linux
 fetch-tsa-certs-linux: ## Build native Linux binary (FIPS)
-	env CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -mod=readonly -tags=no_openssl -buildvcs=false -o fetch_tsa_certs -trimpath ./cmd/fetch-tsa-certs
+	env CGO_ENABLED=0 GOFIPS140=v1.0.0 go build $(BUILD_FLAGS) -o fetch_tsa_certs ./cmd/fetch-tsa-certs
 
-.PHONY:
+.PHONY: fetch-tsa-certs-linux-amd64
+fetch-tsa-certs-linux-amd64: ## Build for Linux amd64
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=linux GOARCH=amd64 go build $(BUILD_FLAGS) -o fetch_tsa_certs_linux_amd64 ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-linux-arm64
+fetch-tsa-certs-linux-arm64: ## Build for Linux arm64
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=linux GOARCH=arm64 go build $(BUILD_FLAGS) -o fetch_tsa_certs_linux_arm64 ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-linux-ppc64le
+fetch-tsa-certs-linux-ppc64le: ## Build for Linux ppc64le
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=linux GOARCH=ppc64le go build $(BUILD_FLAGS) -o fetch_tsa_certs_linux_ppc64le ./cmd/fetch-tsa-certs
+
+.PHONY: fetch-tsa-certs-linux-s390x
+fetch-tsa-certs-linux-s390x: ## Build for Linux s390x
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=linux GOARCH=s390x go build $(BUILD_FLAGS) -o fetch_tsa_certs_linux_s390x ./cmd/fetch-tsa-certs
+
+.PHONY: cross-platform
 cross-platform: fetch-tsa-certs-darwin-arm64 fetch-tsa-certs-darwin-amd64 fetch-tsa-certs-windows ## Build all distributable (cross-platform) binaries
+
+.PHONY: all-platforms
+all-platforms: fetch-tsa-certs-linux-amd64 fetch-tsa-certs-linux-arm64 fetch-tsa-certs-linux-ppc64le fetch-tsa-certs-linux-s390x cross-platform ## Build all binaries for all platforms
 
 .PHONY:	fetch-tsa-certs-darwin-arm64
 fetch-tsa-certs-darwin-arm64: ## Build for mac M1
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build -mod=readonly -buildvcs=false -o fetch_tsa_certs_darwin_arm64 -trimpath ./cmd/fetch-tsa-certs
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o fetch_tsa_certs_darwin_arm64 ./cmd/fetch-tsa-certs
 
 .PHONY: fetch-tsa-certs-darwin-amd64
 fetch-tsa-certs-darwin-amd64:  ## Build for Darwin (macOS)
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build -mod=readonly -buildvcs=false -o fetch_tsa_certs_darwin_amd64 -trimpath ./cmd/fetch-tsa-certs
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build $(BUILD_FLAGS) -o fetch_tsa_certs_darwin_amd64 ./cmd/fetch-tsa-certs
 
 .PHONY: fetch-tsa-certs-windows
 fetch-tsa-certs-windows: ## Build for Windows
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build -mod=readonly -buildvcs=false -o fetch_tsa_certs_windows_amd64.exe -trimpath ./cmd/fetch-tsa-certs
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build $(BUILD_FLAGS) -o fetch_tsa_certs_windows_amd64.exe ./cmd/fetch-tsa-certs

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-cross-platform
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-all-platforms
 ENV APP_ROOT=/opt/app-root \
     GOPATH=/opt/app-root
 
@@ -7,46 +7,38 @@ WORKDIR $APP_ROOT/src
 ADD go.mod go.sum ./
 ADD ./ ./
 
-RUN git config --global --add safe.directory /opt/app-root/src && \
-    go mod download && \
-    make -f Build.mak cross-platform
-
-FROM --platform=linux/amd64   quay.io/securesign/fetch-tsa-certs@sha256:83b5762cd5c7a041727da61038215960dbb828fd93979140be1216f45e185253 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/fetch-tsa-certs@sha256:83b5762cd5c7a041727da61038215960dbb828fd93979140be1216f45e185253 AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/fetch-tsa-certs@sha256:83b5762cd5c7a041727da61038215960dbb828fd93979140be1216f45e185253 AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/fetch-tsa-certs@sha256:83b5762cd5c7a041727da61038215960dbb828fd93979140be1216f45e185253 AS build-s390x
+RUN go mod download && \
+    make -f Build.mak all-platforms
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS packager
 USER root
 RUN mkdir -p /binaries
 
-# fetch_tsa_certs: Native Linux binaries from each arch variant
-COPY --from=build-amd64 /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+COPY --from=build-all-platforms /opt/app-root/src/fetch_tsa_certs_linux_amd64 /tmp/fetch_tsa_certs
 RUN tar -czf /binaries/fetch_tsa_certs_linux_amd64.tar.gz -C /tmp fetch_tsa_certs && \
     rm /tmp/fetch_tsa_certs
 
-COPY --from=build-arm64 /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+COPY --from=build-all-platforms /opt/app-root/src/fetch_tsa_certs_linux_arm64 /tmp/fetch_tsa_certs
 RUN tar -czf /binaries/fetch_tsa_certs_linux_arm64.tar.gz -C /tmp fetch_tsa_certs && \
     rm /tmp/fetch_tsa_certs
 
-COPY --from=build-ppc64le /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+COPY --from=build-all-platforms /opt/app-root/src/fetch_tsa_certs_linux_ppc64le /tmp/fetch_tsa_certs
 RUN tar -czf /binaries/fetch_tsa_certs_linux_ppc64le.tar.gz -C /tmp fetch_tsa_certs && \
     rm /tmp/fetch_tsa_certs
 
-COPY --from=build-s390x /usr/local/bin/fetch_tsa_certs /tmp/fetch_tsa_certs
+COPY --from=build-all-platforms /opt/app-root/src/fetch_tsa_certs_linux_s390x /tmp/fetch_tsa_certs
 RUN tar -czf /binaries/fetch_tsa_certs_linux_s390x.tar.gz -C /tmp fetch_tsa_certs && \
     rm /tmp/fetch_tsa_certs
 
-# fetch_tsa_certs: Cross-compiled binaries
-COPY --from=build-cross-platform /opt/app-root/src/fetch_tsa_certs_darwin_amd64 /tmp/fetch_tsa_certs_darwin_amd64
+COPY --from=build-all-platforms /opt/app-root/src/fetch_tsa_certs_darwin_amd64 /tmp/fetch_tsa_certs_darwin_amd64
 RUN tar -czf /binaries/fetch_tsa_certs_darwin_amd64.tar.gz -C /tmp fetch_tsa_certs_darwin_amd64 && \
     rm /tmp/fetch_tsa_certs_darwin_amd64
 
-COPY --from=build-cross-platform /opt/app-root/src/fetch_tsa_certs_darwin_arm64 /tmp/fetch_tsa_certs_darwin_arm64
+COPY --from=build-all-platforms /opt/app-root/src/fetch_tsa_certs_darwin_arm64 /tmp/fetch_tsa_certs_darwin_arm64
 RUN tar -czf /binaries/fetch_tsa_certs_darwin_arm64.tar.gz -C /tmp fetch_tsa_certs_darwin_arm64 && \
     rm /tmp/fetch_tsa_certs_darwin_arm64
 
-COPY --from=build-cross-platform /opt/app-root/src/fetch_tsa_certs_windows_amd64.exe /tmp/fetch_tsa_certs_windows_amd64.exe
+COPY --from=build-all-platforms /opt/app-root/src/fetch_tsa_certs_windows_amd64.exe /tmp/fetch_tsa_certs_windows_amd64.exe
 RUN tar -czf /binaries/fetch_tsa_certs_windows_amd64.tar.gz -C /tmp fetch_tsa_certs_windows_amd64.exe && \
     rm /tmp/fetch_tsa_certs_windows_amd64.exe
 
@@ -65,6 +57,6 @@ LABEL com.redhat.component="fetch-tsa-certs-cli-stack"
 LABEL name="rhtas/fetch-tsa-certs-cli-stack"
 
 COPY --from=packager /binaries/ /binaries/
-COPY --from=build-amd64 /licenses/ /licenses/
+COPY --from=build-all-platforms /opt/app-root/src/LICENSE /licenses/license.txt
 
 USER 65532:65532

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -1,22 +1,9 @@
-FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 as build-env
-ENV APP_ROOT=/opt/app-root
-ENV GOPATH=$APP_ROOT
-ENV CGO_ENABLED=0
-ENV GOFIPS140=v1.0.0
-WORKDIR $APP_ROOT/src/
-
-ADD go.mod go.sum $APP_ROOT/src/
-RUN go mod download
-
-ADD ./cmd/ $APP_ROOT/src/cmd/
-ADD ./pkg/ $APP_ROOT/src/pkg/
-ADD ./Build.mak $APP_ROOT/src/Build.mak
-
-RUN make -f Build.mak fetch-tsa-certs-linux
+ARG CLI_STACK_IMAGE=quay.io/securesign/fetch-tsa-certs-cli-stack:latest
+FROM --platform=linux/amd64 ${CLI_STACK_IMAGE} AS cli-stack
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
-ENV APP_ROOT=/opt/app-root
-WORKDIR $APP_ROOT/src/
+
+ARG TARGETARCH
 
 LABEL description="The fetch_tsa_certs binary is a cli used to configure the kms and tink signer types for Timestamp Authority."
 LABEL io.k8s.description="The fetch_tsa_certs binary is a cli used to configure the kms and tink signer types for Timestamp Authority."
@@ -26,9 +13,10 @@ LABEL summary="Provides fetch_tsa_certs images."
 LABEL com.redhat.component="fetch_tsa_certs"
 LABEL name="rhtas/fetch-tsa-certs-rhel9"
 
-COPY LICENSE /licenses/license.txt
-
-COPY --from=build-env $APP_ROOT/src/fetch_tsa_certs /usr/local/bin/fetch_tsa_certs
+COPY --from=cli-stack /licenses/license.txt /licenses/license.txt
+COPY --from=cli-stack /binaries/ /tmp/binaries/
+RUN tar -xzf /tmp/binaries/fetch_tsa_certs_linux_${TARGETARCH}.tar.gz -C /usr/local/bin/ && \
+    rm -rf /tmp/binaries
 
 USER 65532:65532
 

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -1,9 +1,13 @@
 ARG CLI_STACK_IMAGE=quay.io/securesign/fetch-tsa-certs-cli-stack:latest
 FROM --platform=linux/amd64 ${CLI_STACK_IMAGE} AS cli-stack
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
-
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS extractor
 ARG TARGETARCH
+COPY --from=cli-stack /binaries/ /tmp/binaries/
+RUN tar -xzf /tmp/binaries/fetch_tsa_certs_linux_${TARGETARCH}.tar.gz -C /tmp/ && \
+    rm -rf /tmp/binaries
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 
 LABEL description="The fetch_tsa_certs binary is a cli used to configure the kms and tink signer types for Timestamp Authority."
 LABEL io.k8s.description="The fetch_tsa_certs binary is a cli used to configure the kms and tink signer types for Timestamp Authority."
@@ -14,12 +18,7 @@ LABEL com.redhat.component="fetch_tsa_certs"
 LABEL name="rhtas/fetch-tsa-certs-rhel9"
 
 COPY --from=cli-stack /licenses/license.txt /licenses/license.txt
-COPY --from=cli-stack /binaries/ /tmp/binaries/
-RUN microdnf install -y tar gzip && \
-    tar -xzf /tmp/binaries/fetch_tsa_certs_linux_${TARGETARCH}.tar.gz -C /usr/local/bin/ && \
-    rm -rf /tmp/binaries && \
-    microdnf remove -y tar gzip && \
-    microdnf clean all
+COPY --from=extractor /tmp/fetch_tsa_certs /usr/local/bin/fetch_tsa_certs
 
 USER 65532:65532
 

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -15,8 +15,11 @@ LABEL name="rhtas/fetch-tsa-certs-rhel9"
 
 COPY --from=cli-stack /licenses/license.txt /licenses/license.txt
 COPY --from=cli-stack /binaries/ /tmp/binaries/
-RUN tar -xzf /tmp/binaries/fetch_tsa_certs_linux_${TARGETARCH}.tar.gz -C /usr/local/bin/ && \
-    rm -rf /tmp/binaries
+RUN microdnf install -y tar gzip && \
+    tar -xzf /tmp/binaries/fetch_tsa_certs_linux_${TARGETARCH}.tar.gz -C /usr/local/bin/ && \
+    rm -rf /tmp/binaries && \
+    microdnf remove -y tar gzip && \
+    microdnf clean all
 
 USER 65532:65532
 

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -2,6 +2,7 @@ ARG CLI_STACK_IMAGE=quay.io/securesign/fetch-tsa-certs-cli-stack:latest
 FROM --platform=linux/amd64 ${CLI_STACK_IMAGE} AS cli-stack
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS extractor
+USER root
 ARG TARGETARCH
 COPY --from=cli-stack /binaries/ /tmp/binaries/
 RUN tar -xzf /tmp/binaries/fetch_tsa_certs_linux_${TARGETARCH}.tar.gz -C /tmp/ && \

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -1,5 +1,5 @@
-ARG CLI_STACK_REF=quay.io/securesign/fetch-tsa-certs-cli-stack:latest
-FROM --platform=linux/amd64 ${CLI_STACK_REF} AS cli-stack
+ARG IMG=quay.io/securesign/fetch-tsa-certs-cli-stack:latest
+FROM --platform=linux/amd64 ${IMG} AS cli-stack
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS extractor
 USER root

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -1,5 +1,5 @@
-ARG CLI_STACK_IMAGE=quay.io/securesign/fetch-tsa-certs-cli-stack:latest
-FROM --platform=linux/amd64 ${CLI_STACK_IMAGE} AS cli-stack
+ARG CLI_STACK_REF=quay.io/securesign/fetch-tsa-certs-cli-stack:latest
+FROM --platform=linux/amd64 ${CLI_STACK_REF} AS cli-stack
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS extractor
 USER root


### PR DESCRIPTION
## Summary

- Invert the dependency between `fetch-tsa-certs` and `fetch-tsa-certs-cli-stack` so the cli-stack builds first and the component image extracts binaries from it
- Eliminates Konflux nudges between the two components by using the existing `wait-for-pipelinerun` task (same pattern as operator-bundle builds)
- Since `CGO_ENABLED=0` across all Build.mak targets, the cli-stack cross-compiles all 7 binaries from a single amd64 builder

### How it works

1. Same commit triggers both PipelineRuns (identical CEL path filters)
2. `fetch-tsa-certs` pipeline uses `manager-pipelinerun-selector` to wait for `fetch-tsa-certs-cli-stack` to complete
3. The cli-stack digest is injected as `CLI_STACK_IMAGE` build arg into the component Dockerfile
4. Each multi-platform builder extracts the correct binary using `TARGETARCH`

### Changes

| File | Change |
|---|---|
| `Build.mak` | Add Linux cross-compilation targets (amd64, arm64, ppc64le, s390x) and `all-platforms` meta-target |
| `Dockerfile.cli-stack.rh` | Build all 7 binaries from source in a single stage (no external image dependency) |
| `Dockerfile.fetch_tsa_certs.rh` | Extract binary from cli-stack image using `TARGETARCH` (no source compilation) |
| `.tekton/*-cli-stack-*.yaml` | Add CEL path filters for source changes |
| `.tekton/fetch-tsa-certs-*.yaml` | Add `manager-pipelinerun-selector` to wait for cli-stack; remove `go_unit_test`, `prefetch-input` |

### Risk

`FROM --platform=linux/amd64 ${CLI_STACK_IMAGE}` on non-amd64 builders — Buildah may reject cross-platform FROM. If so, fallback to auto-merge nudge pattern.

### Related

- SECURESIGN-4992
- Reuses the `wait-for-pipelinerun` task from `securesign/pipelines` (same mechanism as operator-bundle builds)
- Companion change needed in `pipelines` repo: remove `build-nudges-ref` from `fetch-tsa` component config

## Test plan

- [ ] Verify cli-stack PipelineRun builds all 7 binaries from source
- [ ] Verify component PipelineRun waits for cli-stack and receives the correct digest
- [ ] Verify multi-platform builders each extract the correct arch binary
- [ ] Verify no nudge PRs are created between cli-stack and component
- [ ] Test the `FROM --platform=linux/amd64` pattern works on arm64/ppc64le/s390x builders