### PR TITLE
feat: FIPS 140-3 compliance improvements for Go 1.26 native module

### DIFF
--- a/.github/workflows/codeql_analysis.yaml
+++ b/.github/workflows/codeql_analysis.yaml
@@ -57,9 +57,6 @@ jobs:
         build-mode: manual
         dependency-caching: true
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: go mod edit -dropgodebug=fips140
-
     - name: Build Code
       run: |
         make all test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,8 +55,6 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: go mod edit -dropgodebug=fips140
       - name: Build timestamp CLI
         run: make timestamp-cli
       - name: Run Go tests
@@ -103,8 +101,6 @@ jobs:
           go-version-file: './go.mod'
           check-latest: true
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: go mod edit -dropgodebug=fips140
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:

--- a/Build.mak
+++ b/Build.mak
@@ -1,4 +1,4 @@
-FIPS_MODULE ?= latest
+FIPS_MODULE ?= v1.0.0
 
 .PHONY: fetch-tsa-certs-linux
 fetch-tsa-certs-linux: ## Build native Linux binary (FIPS)

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -9,6 +9,7 @@ ADD ./ ./
 
 RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod download && \
+    go mod edit -godebug=fips140=auto && \
     make -f Build.mak cross-platform
 
 FROM --platform=linux/amd64   quay.io/securesign/fetch-tsa-certs@sha256:7a02ddc6d9ddc7b536224bb65fd3a57647c0ecb0f2bc6528703715a132a531ee AS build-amd64

--- a/Dockerfile.fetch_tsa_certs.rh
+++ b/Dockerfile.fetch_tsa_certs.rh
@@ -1,4 +1,5 @@
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1784090680@sha256:e1ff4f548dfca084c2318d11dccd7d30a75c81a3a4fd8abcebc42ea42dd683e8 as build-env
+USER root
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=0
@@ -12,7 +13,8 @@ ADD ./cmd/ $APP_ROOT/src/cmd/
 ADD ./pkg/ $APP_ROOT/src/pkg/
 ADD ./Build.mak $APP_ROOT/src/Build.mak
 
-RUN make -f Build.mak fetch-tsa-certs-linux
+RUN go mod edit -godebug=fips140=auto && \
+    make -f Build.mak fetch-tsa-certs-linux
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab
 ENV APP_ROOT=/opt/app-root

--- a/Dockerfile.tsa.rh
+++ b/Dockerfile.tsa.rh
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1784090680@sha256:e1ff4f548dfca084c2318d11dccd7d30a75c81a3a4fd8abcebc42ea42dd683e8 AS builder
+USER root
 ENV CGO_ENABLED=0
 ENV GOFIPS140=v1.0.0
 ENV APP_ROOT=/opt/app-root
@@ -26,6 +27,7 @@ ADD ./pkg/ $APP_ROOT/src/pkg/
 
 RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod download && \
+    go mod edit -godebug=fips140=auto && \
     go build -mod=readonly -tags=no_openssl -ldflags "${SERVER_LDFLAGS}" ./cmd/timestamp-server
 
 # debug compile options & debugger

--- a/cmd/fetch-tsa-certs/fetch_tsa_certs.go
+++ b/cmd/fetch-tsa-certs/fetch_tsa_certs.go
@@ -18,7 +18,6 @@ package main
 import (
 	"context"
 	"crypto"
-	"crypto/ed25519"
 	"crypto/fips140"
 	"crypto/rand"
 	"crypto/x509"
@@ -110,12 +109,6 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 	if err != nil {
 		return nil, err
 	}
-	// RHTAS FIPS - DO NOT REMOVE
-	// ========================================
-	if _, ok := parentSigner.Public().(ed25519.PublicKey); ok && fips140.Enabled() {
-		return nil, fmt.Errorf("ed25519 is not supported in FIPS mode")
-	}
-	// ========================================
 	parentPubKey := parentSigner.Public()
 	parentPEMPubKey, err := cryptoutils.MarshalPublicKeyToPEM(parentPubKey)
 	if err != nil {
@@ -256,12 +249,6 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 		if err != nil {
 			return nil, err
 		}
-		// RHTAS FIPS - DO NOT REMOVE
-		// ========================================
-		if _, ok := leafKMSSigner.Public().(ed25519.PublicKey); ok && fips140.Enabled() {
-			return nil, fmt.Errorf("ed25519 is not supported in FIPS mode")
-		}
-		// ========================================
 	} else {
 		primaryKey, err := signer.GetPrimaryKey(ctx, tinkKmsKey, "")
 		if err != nil {
@@ -281,12 +268,6 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 		if err != nil {
 			return nil, err
 		}
-		// RHTAS FIPS - DO NOT REMOVE
-		// ========================================
-		if _, ok := leafKMSSigner.Public().(ed25519.PublicKey); ok && fips140.Enabled() {
-			return nil, fmt.Errorf("ed25519 is not supported in FIPS mode")
-		}
-		// ========================================
 	}
 
 	leafPubKey := leafKMSSigner.Public()

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/sigstore/timestamp-authority/v2
 
 go 1.26
 
-godebug fips140=auto
-
 require (
 	cloud.google.com/go/security v1.25.0
 	github.com/beevik/ntp v1.5.0

--- a/pkg/signer/file.go
+++ b/pkg/signer/file.go
@@ -66,12 +66,6 @@ func NewFileSigner(keyPath, keyPass string, hash crypto.Hash) (*File, error) {
 		}
 		return &File{signer}, nil
 	case ed25519.PrivateKey:
-		// RHTAS FIPS - DO NOT REMOVE
-		// ========================================
-		if fips140.Enabled() {
-			return nil, fmt.Errorf("ed25519 is not supported in FIPS mode")
-		}
-		// ========================================
 		signer, err := signature.LoadED25519SignerVerifier(pk)
 		if err != nil {
 			return nil, err

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -17,9 +17,7 @@ package signer
 import (
 	"context"
 	"crypto"
-	"crypto/ed25519"
 	"crypto/elliptic"
-	"crypto/fips140"
 	"crypto/rand"
 	"fmt"
 	"strings"
@@ -52,14 +50,6 @@ func NewCryptoSigner(ctx context.Context, hash crypto.Hash, signer, kmsKey, tink
 			return nil, err
 		}
 		s, _, err := signer.CryptoSigner(ctx, func(_ error) {})
-		// RHTAS FIPS - DO NOT REMOVE
-		// ========================================
-		if err == nil && fips140.Enabled() {
-			if _, ok := s.Public().(ed25519.PublicKey); ok {
-				return nil, fmt.Errorf("ed25519 is not supported in FIPS mode")
-			}
-		}
-		// ========================================
 		return s, err
 	case TinkScheme:
 		primaryKey, err := GetPrimaryKey(ctx, tinkKmsKey, hcVaultToken)

--- a/pkg/signer/tink.go
+++ b/pkg/signer/tink.go
@@ -17,10 +17,7 @@ package signer
 import (
 	"context"
 	"crypto"
-	"crypto/ed25519"
-	"crypto/fips140"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,12 +47,6 @@ func NewTinkSigner(tinkKeysetPath string, primaryKey tink.AEAD) (crypto.Signer, 
 	if err != nil {
 		return nil, err
 	}
-	// RHTAS FIPS - DO NOT REMOVE
-	// ========================================
-	if _, ok := signer.Public().(ed25519.PublicKey); ok && fips140.Enabled() {
-		return nil, fmt.Errorf("ed25519 is not supported in FIPS mode")
-	}
-	// ========================================
 	return signer, nil
 }
 


### PR DESCRIPTION
- **Allow Ed25519 in FIPS mode**: Ed25519 is approved under FIPS 186-5 (CAVP cert A6650)
  and implemented inside Go's native FIPS module. Removed the overly conservative guards
  that blocked Ed25519 keys across all signer types (file, KMS, Tink) and fetch-tsa-certs.
- **Move `godebug fips140=auto` from go.mod to build-time injection**: The directive in
  go.mod required `go mod edit -dropgodebug=fips140` workarounds in every upstream CI
  workflow. Now injected via `go mod edit -godebug=fips140=auto` in the Red Hat Dockerfiles
  at build time, keeping FIPS behavior identical in production while making the repo fully
  compatible with upstream Go.
- **Set `FIPS_MODULE` default to `v1.0.0`** in Build.mak for consistency across all
  build targets.