### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/fetch-tsa-certs-cli-stack-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-cli-stack-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: git-url

--- a/.tekton/fetch-tsa-certs-cli-stack-push.yaml
+++ b/.tekton/fetch-tsa-certs-cli-stack-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: git-url

--- a/.tekton/fetch-tsa-certs-pull-request.yaml
+++ b/.tekton/fetch-tsa-certs-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/fetch-tsa-certs-push.yaml
+++ b/.tekton/fetch-tsa-certs-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/timestamp-authority-pull-request.yaml
+++ b/.tekton/timestamp-authority-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/timestamp-authority-push.yaml
+++ b/.tekton/timestamp-authority-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [ ] Verify Tekton pipeline definitions are valid YAML
- [ ] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)